### PR TITLE
fix-在全局CSS中修复了ID为app的部分，由于子页面通过嵌套在app.vue实现跳转，修改后使得页面得以撑满全屏

### DIFF
--- a/lottery/src/style.css
+++ b/lottery/src/style.css
@@ -58,12 +58,21 @@ button:focus-visible {
   padding: 2em;
 }
 
-#app {
+/* #app {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 0vw;
   text-align: center;
+}  以上是app这个id的原本CSS设置*/
+
+#app {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
+/* 为了让app撑满全屏以使得嵌套在里面的子页面能利用全屏空间而做的修改 */
 
 @media (prefers-color-scheme: light) {
   :root {


### PR DESCRIPTION
在全局CSS中修复了ID为app的部分，由于子页面通过嵌套在app.vue实现跳转，修改后使得页面得以撑满全屏
<img width="1280" alt="微信图片_20250301145509" src="https://github.com/user-attachments/assets/6bce55bf-e4cd-444e-be90-a5176cd69c8f" />
<img width="1280" alt="微信图片_20250301145514" src="https://github.com/user-attachments/assets/6f13fc51-d62d-442b-9c09-c2a0fd218da0" />
<img width="459" alt="微信图片_20250301145517" src="https://github.com/user-attachments/assets/560c5037-c02a-4996-a262-02e60f65d062" />
